### PR TITLE
FLOW-312  Replace ResourceBundleManager with ResourceBundle

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   <!-- Arifact name and version information -->
   <groupId>net.snowflake</groupId>
   <artifactId>snowflake-ingest-sdk</artifactId>
-  <version>3.0.1-20250113</version>
+  <version>3.0.1-20250122-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>Snowflake Ingest SDK</name>
   <description>Snowflake Ingest SDK</description>

--- a/src/main/java/net/snowflake/ingest/utils/SFException.java
+++ b/src/main/java/net/snowflake/ingest/utils/SFException.java
@@ -4,20 +4,24 @@
 
 package net.snowflake.ingest.utils;
 
-import net.snowflake.client.jdbc.internal.snowflake.common.core.ResourceBundleManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import java.text.MessageFormat;
+import java.util.ResourceBundle;
 
 /** Snowflake exception in the Ingest SDK */
 public class SFException extends RuntimeException {
   static final Logger logger = LoggerFactory.getLogger(SFException.class);
-
-  static final ResourceBundleManager errorResourceBundleManager =
-      ResourceBundleManager.getSingleton(ErrorCode.errorMessageResource);
+  static final ResourceBundle errorMessageBundle = ResourceBundle.getBundle(ErrorCode.errorMessageResource);
 
   private Throwable cause;
   private String vendorCode;
   private Object[] params;
+
+  private static String getErrorMessage(final ErrorCode errorCode, final Object... params) {
+    final String messageTemplate = errorMessageBundle.getString(errorCode.getMessageCode());
+    return MessageFormat.format(messageTemplate, params);
+  }
 
   /**
    * Construct a Snowflake exception from a cause, an error code and message parameters
@@ -27,10 +31,7 @@ public class SFException extends RuntimeException {
    * @param params
    */
   public SFException(Throwable cause, ErrorCode errorCode, Object... params) {
-    super(
-        errorResourceBundleManager.getLocalizedMessage(
-            String.valueOf(errorCode.getMessageCode()), params),
-        cause);
+    super(getErrorMessage(errorCode, params), cause);
 
     this.vendorCode = errorCode.getMessageCode();
     this.params = params;


### PR DESCRIPTION
[FLOW-312](https://snowflakecomputing.atlassian.net/browse/FLOW-312) Replace ResourceBundleManager with direct usage of java.util.ResourceBundle to properly load ingest_error_messages resource file. This fixes a resource loading issue due to the class loader of ResourceBundleManager being a parent of the Snowpipe NAR so it cannot access the resources in the Snowpipe NAR.

---

Why ResourceBundle over ResourceBundleManager? ResourceBundleManager has a bunch of logic to check for multiple resource files based on the system's Locale. However in the snowflake-ingest-java project, a single properties file that is not Locale specific is present, `ingest_error_messages.properties`.